### PR TITLE
Fix 2FA code capture from Google Messages

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -24,7 +24,8 @@ fetch(chrome.runtime.getURL('patterns.json'))
 
 function extract2FACode(text) {
     for (let pattern of codePatterns) {
-        const regex = new RegExp(pattern.platformPattern, 'i');
+        // Use 'i' flag for case-insensitive and 's' flag for dotAll (. matches newlines)
+        const regex = new RegExp(pattern.platformPattern, 'is');
         const match = text.match(regex);
         if (match && match[1]) {
             console.log(`Code matched for platform ${pattern.platformName}:`, match[1]);
@@ -34,7 +35,7 @@ function extract2FACode(text) {
             };
         }
     }
-    console.log('No code match found for text:', text);
+    console.log('No code match found for text:', text.substring(0, 200));
     return null;
 }
 
@@ -51,27 +52,63 @@ function isUnreadMessage(element) {
   return isUnread;
 }
 
+function extractMessageText(element) {
+  // Try multiple selectors to get message text
+  const selectors = [
+    '.snippet-text span[dir="auto"]',  // Conversation list snippet
+    '.text-msg span[dir="ltr"]',       // Actual message content (common format)
+    '.text-msg span[dir="auto"]',      // Actual message content (alternative)
+    '.text-msg',                        // Fallback to text-msg container
+    'div[jsname] span[dir="ltr"]',     // Generic message span
+    'div[jsname] span[dir="auto"]'     // Generic message span alternative
+  ];
+
+  for (const selector of selectors) {
+    const textElement = element.querySelector(selector);
+    if (textElement) {
+      const text = textElement.textContent.trim();
+      if (text) {
+        console.log(`Found message text using selector "${selector}":`, text);
+        return text;
+      }
+    }
+  }
+
+  // Fallback: try to get any text content from the element
+  const text = element.textContent.trim();
+  if (text) {
+    console.log('Using element textContent as fallback:', text.substring(0, 100));
+    return text;
+  }
+
+  console.log('No message text found in element');
+  return null;
+}
+
 function processMessage(element) {
   console.log('Processing message element:', element);
-  if (!isUnreadMessage(element)) {
-      console.log('Message is not unread, skipping');
+
+  // For actual messages in conversation, we don't require the unread check
+  // as they may already be marked as read when we process them
+  const isInConversationView = !!element.closest('.conversation-content, [role="main"]');
+
+  if (!isInConversationView && !isUnreadMessage(element)) {
+      console.log('Message is not unread and not in conversation view, skipping');
       return;
   }
 
-  // Look for the specific element containing the message text
-  const snippetElement = element.querySelector('.snippet-text span[dir="auto"]');
-  if (!snippetElement) {
-      console.log('Snippet text element not found, skipping');
+  const messageText = extractMessageText(element);
+  if (!messageText) {
+      console.log('No message text found, skipping');
       return;
   }
 
-  const messageText = snippetElement.textContent.trim();
   console.log('Processing message text:', messageText);
   const codeInfo = extract2FACode(messageText);
   if (codeInfo && !processedCodes.has(codeInfo.code)) {
       console.log(`2FA code found: ${codeInfo.code} (${codeInfo.platform})`);
       processedCodes.add(codeInfo.code);
-      
+
       try {
           chrome.runtime.sendMessage({
               action: "processPendingCode",
@@ -149,10 +186,20 @@ function startObserving() {
               if (mutation.type === 'childList') {
                   mutation.addedNodes.forEach(node => {
                       if (node.nodeType === Node.ELEMENT_NODE) {
+                          // Check if it's an unread message in the list
                           if (isUnreadMessage(node)) {
                               processMessage(node);
                           }
+                          // Check for unread messages within the added node
                           node.querySelectorAll('.unread, [data-e2e-is-unread="true"]').forEach(processMessage);
+
+                          // Check if it's a new message in the conversation view
+                          // Look for elements with text-msg class (actual messages)
+                          if (node.classList?.contains('text-msg') || node.querySelector('.text-msg')) {
+                              processMessage(node);
+                          }
+                          // Also check for message bubbles that might contain 2FA codes
+                          node.querySelectorAll('.text-msg, [jsname] .message-text').forEach(processMessage);
                       }
                   });
               } else if (mutation.type === 'attributes') {
@@ -174,14 +221,15 @@ function startObserving() {
   observer.observe(targetNode, config);
   console.log('MutationObserver started');
 
-  // Initial scan of existing unread messages
-  targetNode.querySelectorAll('.unread, [data-e2e-is-unread="true"]').forEach(processMessage);
+  // Initial scan of existing unread messages and conversation messages
+  targetNode.querySelectorAll('.unread, [data-e2e-is-unread="true"], .text-msg').forEach(processMessage);
 }
 
 // Add a function to periodically check for new messages
 function periodicCheck() {
   console.log('Performing periodic check for new messages');
-  document.querySelectorAll('.unread, [data-e2e-is-unread="true"]').forEach(processMessage);
+  // Check both unread messages in list and messages in open conversation
+  document.querySelectorAll('.unread, [data-e2e-is-unread="true"], .text-msg').forEach(processMessage);
 }
 
 // Set up periodic checking

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "2F2Chrome",
-  "version": "1.2",
+  "version": "1.3",
   "description": "Automatically captures 2FA codes from Google Messages",
   "permissions": [
     "storage",


### PR DESCRIPTION
Previously, the extension only detected 2FA codes in message preview snippets in the conversation list. This caused it to miss codes when users had a conversation open and were viewing the actual messages.

Changes:
- Added extractMessageText() function with multiple selectors for both conversation list snippets and actual message content
- Updated processMessage() to handle messages in conversation view
- Modified MutationObserver to detect new messages in open conversations
- Updated periodic checks to scan messages in conversation view
- Fixed regex matching to support multiline patterns with 's' flag

This should resolve the issue where codes are visible in Google Messages but not captured by the extension.